### PR TITLE
Added DAQ channels for PIV trigger

### DIFF
--- a/DAQandMotorControl/Libraries/Run/run_Motors.m
+++ b/DAQandMotorControl/Libraries/Run/run_Motors.m
@@ -1,6 +1,6 @@
 function [flume, out, dat, Prof_out_angle, Prof_out,last_out, freq,pitch2, heave2, pitch3, heave3,phase13, num_cyc, phi, foiltype]...
     = run_Motors(dq,last_out,pitch_bias,Wbias,Gbias,accbias,foiltype, freq, pitch2, heave2, pitch3, heave3, phase13, phi,...
-    num_cyc, transientcycs, constantamplitude)
+    num_cyc, transientcycs, constantamplitude, offset)
 %%
 % Given frequency [Hz], Pitch amplitude [deg] and heave amplitude [chords], this function will run 3 rigs for a set number of cycles
 % NOTE: Considering the frontmost rig was removed (Shawn), it's values are defaulted to 0
@@ -72,15 +72,15 @@ transientcycs2 = transientcycs*freq2/freq3;
 
 
 Prof_out_angle = [Prof1p, Prof1h, Prof2p, Prof2h, Prof3p, Prof3h];
-Prof_out = input_conv_3rigs(Prof_out_angle, freq, heave1, heave2, heave3,pitch_bias); % let's hope this works <-- It does! But something is weird with the signs.
+Prof_out_temp = input_conv_3rigs(Prof_out_angle, freq, heave1, heave2, heave3,pitch_bias); % let's hope this works <-- It does! But something is weird with the signs.
 
 % For PIV trigger
 
-% trig_signal=ones(length(Prof_out_temp(:,1)),1);
-% trig_signal(1:round(1/freq*rate*offset))=0;
-% trig_signal(end-round(1/freq*rate)*1:end)=0;
-% 
-% Prof_out = [Prof_out_temp trig_signal];
+trig_signal=ones(length(Prof_out_temp(:,1)),1);
+trig_signal(1:round(1/freq*dq.Rate*offset))=0;
+trig_signal(end-round(1/freq*dq.Rate)*1:end)=0;
+
+Prof_out = [Prof_out_temp trig_signal];
 
 %% Run section
 tic

--- a/DAQandMotorControl/Libraries/Setup/find_bias_3rigs.m
+++ b/DAQandMotorControl/Libraries/Setup/find_bias_3rigs.m
@@ -21,9 +21,9 @@ hprof3=linspace(last_out(6),last_out(6),bias_trialduration*dq.Rate)';
 
 pprof3=linspace(last_out(5),last_out(5),bias_trialduration*dq.Rate)';
 
-trigger=linspace(last_out(6),last_out(6),bias_trialduration*dq.Rate)';
+trigger=linspace(last_out(7),last_out(7),bias_trialduration*dq.Rate)';
 
-output = [pprof1 hprof1 pprof2 hprof2 pprof3 hprof3];  % needs additional trigger channel for PIV
+output = [pprof1 hprof1 pprof2 hprof2 pprof3 hprof3 trigger];  % needs additional trigger channel for PIV
 
 % figure(3)
 % plot(output)

--- a/DAQandMotorControl/Libraries/Setup/move_new_pos_3rigs.m
+++ b/DAQandMotorControl/Libraries/Setup/move_new_pos_3rigs.m
@@ -21,15 +21,16 @@ pprof2=linspace(last_out(3),n_pos(3),dq.Rate*t)';
 hprof2=linspace(last_out(4),n_pos(4),dq.Rate*t)';
 pprof3=linspace(last_out(5),n_pos(5),dq.Rate*t)';
 hprof3=linspace(last_out(6),n_pos(6),dq.Rate*t)';
+trigger=linspace(last_out(7),last_out(7),dq.Rate*t)';
 
-output_prof = [pprof1 hprof1 pprof2 hprof2 pprof3 hprof3];
+output_prof = [pprof1 hprof1 pprof2 hprof2 pprof3 hprof3 trigger];
 
 % dq.IsNotifyWhenDataAvailableExceedsAuto=true;
 % dq.queueOutputData(output_prof);
 % dat = dq.startForeground;
 dat = readwrite(dq,output_prof,"OutputFormat","Matrix");
 
-last_out=[pprof1(end) hprof1(end) pprof2(end),hprof2(end) pprof3(end),hprof3(end)];
+last_out=[pprof1(end) hprof1(end) pprof2(end) hprof2(end) pprof3(end) hprof3(end) trigger(end)];
 
 [out,t]=output_conv_3rigs(dat,Wbias,Gbias,accbias,foil);
 

--- a/DAQandMotorControl/Libraries/Setup/move_to_zero.m
+++ b/DAQandMotorControl/Libraries/Setup/move_to_zero.m
@@ -19,15 +19,16 @@ pprof2=linspace(last_out(3),pitch_bias(2),dq.Rate*2)';
 hprof2=linspace(last_out(4),0,dq.Rate*2)';
 pprof3=linspace(last_out(5),pitch_bias(3),dq.Rate*2)';
 hprof3=linspace(last_out(6),0,dq.Rate*2)';
+trigger=linspace(last_out(7),0,dq.Rate*2)';
 
-output_prof = [pprof1 hprof1 pprof2 hprof2 pprof3 hprof3];
+output_prof = [pprof1 hprof1 pprof2 hprof2 pprof3 hprof3 trigger];
 
 % dq.IsNotifyWhenDataAvailableExceedsAuto=true;
 % dq.queueOutputData(output_prof);
 % dat = dq.startForeground;
 dat = readwrite(dq,output_prof,"OutputFormat","Matrix");
 
-last_out=[pprof1(end) hprof1(end) pprof2(end),hprof2(end) pprof3(end),hprof3(end)];
+last_out=[pprof1(end) hprof1(end) pprof2(end) hprof2(end) pprof3(end) hprof3(end) trigger(end)];
 
 
 end

--- a/DAQandMotorControl/Libraries/Setup/setup_DAQ_channels.m
+++ b/DAQandMotorControl/Libraries/Setup/setup_DAQ_channels.m
@@ -188,9 +188,9 @@ chout6.Name = 'Heave Wallace';
 disp('Analog outputs done. Syncing and Zeroing output...')
 
 %  PIV trigger and pulse train channels
-%     s.addDigitalChannel('dev2','Port0/line14','OutputOnly');% output a trigger signal to the PTU
-%     s.addDigitalChannel('dev2','Port0/line10','InputOnly'); % record the trigger signal
-%     s.addDigitalChannel('dev2','Port0/line9','InputOnly'); % record the pulse signal from the PTU
+    addoutput(dq,'dev2','Port0/line14','Digital');% output a trigger signal to the PTU, Dev2.2, P0.5
+    addinput(dq,'dev2','Port0/line10','Digital'); % record the trigger signal, Dev2.2, P0.1
+    addinput(dq,'dev2','Port0/line9','Digital'); % record the pulse signal from the PTU, Dev2.2, P0.0
 
 
 % addTriggerConnection(s,'Dev1/PFI4','Dev4/PFI0','StartTrigger');

--- a/DAQandMotorControl/run_Afsweep_2rigs.m
+++ b/DAQandMotorControl/run_Afsweep_2rigs.m
@@ -2,11 +2,11 @@
 % and automatically save the output data
 
 startexp = tic;
-experimentnamestr = 'foilandvib';
+experimentnamestr = 'vibPIV';
 foiltype='V1';
-chord=0.06; % meters
-U = 0.3; % m/s
-num_cyc = 10; % must be even?
+chord=0.024; % meters
+U = 0.2; % m/s
+num_cyc = 50; % must be even?
 transientcycs = 5;
 constantpitch = 0; % 1 for constant pitch during trial, only last foil
 A2pitch = 0; % Pitch amplitude in degrees
@@ -14,12 +14,12 @@ A1pitch = 0; % pitch amplitude of upstream foil in degrees
 A1star = 0; % heave amplitude of upstream foil in meters
 phase2 = 0;
 phi = 0;
+offset = 10; % Time (in cycles) from start of run to start PIV
 
-
-for fstar = 0.14:0.02:0.14 %0.06:0.02:0.24  
+for fstar = 0.24:0.02:0.24 %0.06:0.02:0.24  
         freq = fstar*U/chord;
 
-    for A2star = 0.9:0.1:0.9 %0.0:0.1:1.1
+    for A2star = 0:0.1:0 %0.0:0.1:1.1
         A2 = A2star*chord*100;
 
         % Used to specify heave velocity and acceleration limits
@@ -35,9 +35,9 @@ for fstar = 0.14:0.02:0.14 %0.06:0.02:0.24
         [flume, out, dat, Prof_out_angle, Prof_out,last_out, freq,pitch2, heave2, pitch3, heave3,phase13, num_cyc, phi,...
             foiltype]...
         = run_Motors(dq,last_out,pitch_bias,Wbias,Gbias,accbias,foiltype, freq, A1pitch, A1star, A2pitch, A2star, phase2,...
-        phi, num_cyc, transientcycs, constantpitch);
+        phi, num_cyc, transientcycs, constantpitch, offset);
         
-        trialname = [experimentnamestr,'_pitch=',num2str(A2pitch,3),'deg,f=',num2str(freq,3),'Hz,A=',num2str(A2,3),'cm.mat'];
+        trialname = [fname,'\data\',experimentnamestr,'_pitch=',num2str(A2pitch,3),'deg,f=',num2str(freq,3),'Hz,A=',num2str(A2,3),'cm.mat'];
 %         disp('Trial complete, saving data.')
         save(trialname)
     end

--- a/DAQandMotorControl/setup_DAQ.m
+++ b/DAQandMotorControl/setup_DAQ.m
@@ -14,12 +14,12 @@ span = 0.405;
 foil_shape = 'EC1';
 Wall_distance_left = 0.4;
 Wall_distance_right = 0.4;
-flume_height = 0.52;
-flume_hertz = 14.9;
+flume_height = 0.53;
+flume_hertz = 10.4;
 Number_of_foils = 1;
 foil_separation = 0; 
 foil_offset = 0;
-Temperature = 21.4;
+Temperature = 20.9;
 pitch_axis = 0.5;
 piv_var = 0;
 filt_var = 0;
@@ -91,8 +91,8 @@ mkdir([fname,'\data'])
 %     disp('ensure Vectrino and Vector are collecting data and recording to file')
 % end
 
-last_out = [0 0 0 0 0 0];
-write(dq,last_out)
+last_out = [0 0 0 0 0 0 0];
+  write(dq,last_out)
 
 
 % Find bias voltages for force and acceleration sensors


### PR DESCRIPTION
Added DAQ channel definitions for outgoing trigger to function generator, recording of trigger signal, and recording the triggering pulse train from LaVision PTU.  This also required appending one column to the variable "last_out" which is the new outgoing trigger channel.

Also changed the default data save location from the working folder to 'D:\Experiments'